### PR TITLE
update required by react-native-maps to get polylines to work. v0.27.…

### DIFF
--- a/tracks/package.json
+++ b/tracks/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^16.8.6",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
     "react-native-elements": "^1.1.0",
+    "react-native-maps": "0.27.1",
     "react-native-web": "^0.11.4",
     "react-navigation": "^3.11.1"
   },

--- a/tracks/src/components/Map.js
+++ b/tracks/src/components/Map.js
@@ -27,7 +27,7 @@ const Map = () => {
         strokeColor="rgba(158, 158, 255, 1.0)"
         fillColor="rgba(158, 158, 255, 0.3)"
       />
-      <Polyline coordinates={locations.map(loc => loc.coords)} />
+      <Polyline coordinates={locations.map(loc => loc.coords)} lineDashPattern={[1]} />
     </MapView>
   );
 };


### PR DESCRIPTION
Polylines weren't working for me with the version of react-native-maps that got installed. I googled a bit, and read that the version 0.27.1 worked and adding a line dash pattern option to the Polyline helped. I had to do both, I had to switch to the react-native-maps previous version and I had to add the dash pattern option to the Polyline tag.